### PR TITLE
Adding --force option to repair checksums

### DIFF
--- a/scripts/fedora-checksums
+++ b/scripts/fedora-checksums
@@ -255,7 +255,6 @@ class FedoraChecksums(object):
         :param dsobj: :class:`~eulfedora.models.DatastreamObject`
         '''
 
-        # TODO: can we just add or self.args.repair_existing?
         if dsobj.checksum_type == 'DISABLED' or dsobj.checksum == 'none' or dsobj.id in self.args.force_ds_ids:
             dsobj.checksum_type = self.args.checksum_type
             try:


### PR DESCRIPTION
Added --force option that accepts a comma separated list of datastream IDs on which to force checksum regeneration
