### PR TITLE
add 'omit_checksums' to repo-cp and syncutil

### DIFF
--- a/scripts/repo-cp
+++ b/scripts/repo-cp
@@ -70,6 +70,8 @@ def repo_copy():
         help='Fedora export format to use.  Use archive if migrate exports ' \
            + 'fail with checksum errors or if content URLs are not accessible '
            + 'to the destination server. (default: %(default)s)')
+    parser.add_argument('--omit-checksums', default=False, action='store_true',
+        help='Omit checksums from datastreams (default: %(default)s)',)
     parser.add_argument('--archive', '-a', action='store_const',
         const='archive', dest='export_format',
         help='Use archive export format (equivalent to --export-format archive)')
@@ -153,7 +155,7 @@ def repo_copy():
             else:
                 result = sync_object(src_obj, dest_repo, export_context=args.export_format,
                     overwrite=allow_overwrite, show_progress=args.progress,
-                    requires_auth=args.requires_auth)
+                    requires_auth=args.requires_auth, omit_checksums=args.omit_checksums)
                 print('%s copied' % result)
         except ChecksumMismatch:
             print('ChecksumMismatch on %s' % pid)


### PR DESCRIPTION
Though not directly related to `airlock` functionality, thought this might be a good branch to make a pull request for a small addition to `repo-cp` and `syncutil`.

This `omit-checksums` flag for `repo-cp`, or `omit_checksums` arg for `sync_object`, will allow you to scrub `<foxml:contentDigest>` tags (aka checksums) from the FOXML used for ingest into the destination repository.  We were having problems with Redirect (**R**) and External (**E**) datastreams failing checksum tests on the destination repo side.  A further improvement may be targeting them directly, but this blanket approach works as well.

Probably not useful for all transactions, and undoubtedly slows the transfer a bit as it sweeps through and cleans them out, but might be a nice option to have if the risks and effects are understood.